### PR TITLE
Remove testthat from R/

### DIFF
--- a/R/check_inference_model.R
+++ b/R/check_inference_model.R
@@ -73,16 +73,6 @@ check_inference_model <- function(
       )
     }
   )
-  if (length(inference_model$tipdates_filename) != 1) {
-    stop("'tipdates_filename' must have one element")
-  }
-
-  if (
-    !beautier::is_one_na(inference_model$tipdates_filename) &&
-      !beautier::is_one_string(inference_model$tipdates_filename)
-  ) {
-    stop("'tipdates_filename' must be one NA or one string")
-  }
   check_string(inference_model$tipdates_filename, allow_na = TRUE)
   invisible(inference_model)
 }

--- a/R/check_store_every.R
+++ b/R/check_store_every.R
@@ -6,7 +6,6 @@
 check_store_every <- function(store_every) {
   check_number_whole(store_every, allow_na = TRUE, min = -1)
   if (is.na(store_every)) return()
-  testthat::expect_true(beautier::is_one_int(store_every))
 
   if (store_every == 0) {
     stop(

--- a/R/indent.R
+++ b/R/indent.R
@@ -12,7 +12,7 @@ indent <- function(
 ) {
   check_number_whole(n_spaces, min = 0)
 
-  testthat::expect_false(is.null(text))
+  check_false(is.null(text))
   for (i in seq_along(text)) {
     if (text[i] == "") next
     spaces <- paste(rep(" ", n_spaces), collapse = "")

--- a/R/is_one_bool.R
+++ b/R/is_one_bool.R
@@ -19,5 +19,5 @@
 #' @author Richèl J.C. Bilderbeek
 #' @export
 is_one_bool <- function(x) {
-  length(x) == 1 && !is.na(x) && is.logical(x)
+  isTRUE(x) || isFALSE(x)
 }

--- a/tests/testthat/test-check_inference_model.R
+++ b/tests/testthat/test-check_inference_model.R
@@ -140,18 +140,18 @@ test_that("in-depth use", {
     check_inference_model(
       create_inference_model(tipdates_filename = NULL)
     ),
-    "must have one element"
+    "must be a single string"
   )
   expect_error(
     check_inference_model(
       create_inference_model(tipdates_filename = c("nons", "ense"))
     ),
-    "must have one element"
+    "must be a single string"
   )
   expect_error(
     check_inference_model(
       create_inference_model(tipdates_filename = 1)
     ),
-    "must be one NA or one string"
+    "must be a single string or `NA`, not the number 1"
   )
 })


### PR DESCRIPTION
Hi @richelbilderbeek,

With this Pull Request I'd would like to remove testthat from R/ as it is Suggests only. 

The first call was redundant. The input check happens in `check_number_whole()`.
The second one is simply replacing expect_false by check_false that I introduced.

As testthat is only a Suggests, it means that it may not be available to users. (It is not required either to use the package)
